### PR TITLE
(MAINT) - Added validation code to targets filters

### DIFF
--- a/lib/ccsh/hosts.rb
+++ b/lib/ccsh/hosts.rb
@@ -39,7 +39,7 @@ module CCSH
                     host.sudo_enabled = CCSH::Utils.get_options('sudo_enabled', h, @defaults['sudo_enabled'])
                     host.sudo_password = CCSH::Utils.get_options('sudo_passwors', h, @defaults['sudo_password'])
 
-                    # define the password if the sudo_password is not set 
+                    # define the password if the sudo_password is not set
                     host.sudo_password = host.password if host.sudo_password == nil
 
                     host.groups = h['groups']
@@ -56,12 +56,12 @@ module CCSH
         end
 
         def filter_by(targets)
-            return @hosts if targets.include? 'all'
+            return @hosts if targets.include?('all')
 
             hosts = []
             @hosts.each do |host|
                 targets.each do |target|
-                    hosts << host if host.groups.include? target
+                    hosts << host if host.groups != nil && host.groups.include?(target)
                 end
             end
 

--- a/lib/ccsh/utils.rb
+++ b/lib/ccsh/utils.rb
@@ -50,6 +50,8 @@ module CCSH
             puts
         end
 
+        ##
+        # Display host display_hosts_verbosity
         def self.display_hosts_verbosity(hosts)
             hosts.each do |host|
                 CCSH::Utils::verbose("sudo mode enable to host: #{host.hostname}") if host.sudo_enabled
@@ -58,7 +60,24 @@ module CCSH
         end
 
         ##
-        #
+        # Show at least 10 groups names
+        def self.show_groups(hosts)
+            hosts_groups = []
+            hosts.each do |host|
+                if host.groups != nil
+                    host.groups.each do |gname|
+                        hosts_groups.push(gname) unless hosts_groups.include?(gname)
+                    end
+                end
+            end
+
+            hosts_groups.slice(0, 10).each { |gname| puts "  - #{gname}" }
+            puts "Example: ccsh #{hosts_groups[0]}" unless hosts_groups[0] == nil
+            puts "Example: ccsh #{hosts_groups.slice(0,2).join(' ')}" unless hosts_groups.slice(0,2) == nil
+        end
+
+        ##
+        # validate the ssh connection before start the ccsh console
         def self.valid_ssh(options)
             return true
         end


### PR DESCRIPTION
Github Info:
  - Issue: #17 

Changes:
  - Added a validation code and helpful error message when the
    user don't specified the targets
  - Added a validation code and helpful error message when the
    user specified a target that is not listed on the hosts file
  - Added a UTILS functions to show 10 groups from the hosts file
    to help the user when they not type a valid group name. This
    is executed when as part of the error message to help
    the system usage.

The following example will be the error messages for the actions. 
**Use Cases**

1. Run the ccsh without specifying a target. 
```sh
raffs~>$ ccsh
You must specify a target hostname or group name.
Example:
    'ccsh databases' - select all servers from the database group
    'ccsh all'       - select all defined servers
Please run 'ccsh --help' for details

An error occur and system exit with the following message:
  You must specify a target hostname or group name.
```

2. Run the ccsh with a non-valid group name
```sh
raffs~> $ ccsh bogus
Could not found any hosts that matches the given target(s): 'bogus'
Here are some groups found on the file: '/Users/raffs/.ccsh/hosts.yaml'
  - production
  - webserver
  - grupo2
  - grupo1
Example: ccsh production
Example: ccsh production webserver

An error occur and system exit with the following message:
  Could not found any hosts that matches the given target(s): 'bogus'
```